### PR TITLE
Fix R install in validate submission workflow

### DIFF
--- a/.github/workflows/validate-submission.yaml
+++ b/.github/workflows/validate-submission.yaml
@@ -36,14 +36,13 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libcurl4-openssl-dev libfontconfig1-dev
+          sudo apt-get install -y libcurl4-openssl-dev libfontconfig1-dev libharfbuzz-dev libfribidi-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev
 
       - name: Install R packages
         run: |
            Rscript -e 'install.packages("pkgdown")'
            Rscript -e 'install.packages("textshaping")'
            Rscript -e 'install.packages("devtools")'
-           Rscript -e 'devtools::install_deps(dep = TRUE)'
            Rscript -e 'install.packages("curl")'
 
       - name: Install hubUtils from specific branch


### PR DESCRIPTION
* Add missing apt pkg installs for `textshaping`,
* Add missing apt pkg installs for `ragg`, and
* Remove unnecessary `devtools::install_deps` call.